### PR TITLE
Add bug-reports link

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -3,6 +3,7 @@ version: '0.1'
 author: Dan Fithian <daniel.m.fithian@gmail.com>
 maintainer: TVision Insights
 license: MIT
+bug-reports: https://github.com/tvision-insights/interpolator/issues
 synopsis: 'Runtime interpolation of environment variables in records using profunctors'
 description: |
   Runtime interpolation of environment variables in records using profunctors. See


### PR DESCRIPTION
I like having some hyperlink or another to get from the hackage package description page to the github source and/or issue tracker.