### PR TITLE
Remove unnecessary exports and upgrade arbitrary instances

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,12 @@
+1.0.0
+=======
+
+- @asariley
+    - Removed internal symbols `noEnv`, `varNameAllowed`, `maybeGen` from `Data.Interpolation`
+    - Added `instance Arbitrary1 Uninterpolated`
+
+0.1.2
+=======
+
+- @asariley
+    - Updated `TemplateKey` arbitrary instance to only include alpha-numeric and underscore characters.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: interpolator
-version: '0.1.2'
+version: '1.0.0'
 author: Dan Fithian <daniel.m.fithian@gmail.com>
 maintainer: TVision Insights
 license: MIT

--- a/src/Data/Interpolation.hs
+++ b/src/Data/Interpolation.hs
@@ -200,4 +200,3 @@ instance {-# OVERLAPPABLE #-} Arbitrary a => Arbitrary (Uninterpolated a) where
 instance {-# OVERLAPPING #-} Arbitrary (Uninterpolated T.Text) where
   arbitrary = liftArbitrary noEnv
     where noEnv = fmap T.pack $ arbitrary `suchThat` (\ s -> not ("_env:" `isPrefixOf` s) && not (null s))
-

--- a/src/Data/Interpolation.hs
+++ b/src/Data/Interpolation.hs
@@ -18,7 +18,7 @@ import Data.Sequences (isPrefixOf)
 import Data.Set (Set)
 import qualified Data.Text as T
 import System.Environment (getEnvironment)
-import Test.QuickCheck (Arbitrary, Gen, arbitrary, frequency, listOf1, oneof, suchThat)
+import Test.QuickCheck (Arbitrary, Arbitrary1, arbitrary, arbitrary1, liftArbitrary, listOf1, oneof, suchThat)
 import Text.Read (readMaybe)
 
 -- |Newtype wrapper for an environment variable key.
@@ -184,24 +184,20 @@ instance (ToTemplateValue a, ToJSON a) => ToJSON (Uninterpolated a) where
     Templated x -> toJSON x
     Literal x -> toJSON x
 
-maybeGen :: Gen a -> Gen (Maybe a)
-maybeGen x = frequency [(1, pure Nothing), (3, Just <$> x)]
-
-noEnv, varNameAllowed :: Gen T.Text
-noEnv = fmap T.pack $ arbitrary `suchThat` (\ s -> not ("_env:" `isPrefixOf` s) && not (null s))
-varNameAllowed = fmap T.pack . listOf1 $ arbitrary `suchThat` (\c -> isAlphaNum c || c == '_')
-
 instance Arbitrary TemplateKey where
   arbitrary = TemplateKey <$> varNameAllowed
+    where varNameAllowed = fmap T.pack . listOf1 $ arbitrary `suchThat` (\c -> isAlphaNum c || c == '_')
+
+instance Arbitrary1 Uninterpolated where
+  liftArbitrary g = oneof
+    [ Literal <$> g
+    , Templated <$> (Template <$> arbitrary <*> liftArbitrary g)
+    ]
 
 instance {-# OVERLAPPABLE #-} Arbitrary a => Arbitrary (Uninterpolated a) where
-  arbitrary = oneof
-    [ Literal <$> arbitrary
-    , Templated <$> (Template <$> arbitrary <*> arbitrary)
-    ]
+  arbitrary = arbitrary1
 
 instance {-# OVERLAPPING #-} Arbitrary (Uninterpolated T.Text) where
-  arbitrary = oneof
-    [ Literal <$> noEnv
-    , Templated <$> (Template <$> arbitrary <*> maybeGen noEnv)
-    ]
+  arbitrary = liftArbitrary noEnv
+    where noEnv = fmap T.pack $ arbitrary `suchThat` (\ s -> not ("_env:" `isPrefixOf` s) && not (null s))
+


### PR DESCRIPTION
So I kinda got nerd sniped with the right way to write `Arbitrary` instances so I updated the ones here to be more in line with QuickCheck instances. 

So this technically changes the API surface, so it may require a major version bump. It removes `noEnv` `varNameAllowed` and `maybeGen` from the package. Though it would be inappropriate for another package to use these symbols, they were exported so who is to say that no one else does. Perhaps in addition to this change, an explicit export list should be added. 