### PR TITLE
Update release instructions

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,11 +4,13 @@ Outline for releasing this package to Hackage and Stackage
 
 ## Steps
 
-* Bump version in `package.yaml` in this repository. Create a PR with this change.
+* Bump version in `package.yaml` in this repository. Create and merge a PR with this change.
 * `git tag <version> -m "Release version <version>"`
 * `git push origin --tags`
-* `stack sdist`
-* Copy to a folder that can be navigated to for upload
-* Upload here: http://hackage.haskell.org/packages/upload
-* `scripts/hackage-docs.sh <user>`
+* Build and upload to Hackage:
+   * Make sure your workspace is clean
+   * `stack sdist`
+   * Copy to a folder that can be navigated to for upload
+   * Upload here: http://hackage.haskell.org/packages/upload
+   * `scripts/hackage-docs.sh <user>`
 * Create stackage PR if needed

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+1.1.0.2
+======
+
+- @mossprescott
+    - Re-uploading to clean up an extraneous file in the bundle.
+
 1.1.0.1
 ======
 
@@ -11,7 +17,8 @@
 - @mossprescott
     - Added Template Haskell splices to generate polymorphic types and "simple" and "Uninterpolated"
       synonyms: `withUninterpolated`, `withPolymorphic`, and `deriveUninterpolated`.
-
+- Note: this release does not contain any breaking changes, and should have been only a minor
+  version bump (i.e. 1.0.1).
 
 1.0.0
 =======

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: interpolator
-version: '1.1.0.1'
+version: '1.1.0.2'
 author: Dan Fithian <daniel.m.fithian@gmail.com>
 maintainer: TVision Insights
 license: MIT


### PR DESCRIPTION
This release is aimed to clean up my sloppiness in uploading 1.1.0.1 with an extra file from my workspace. I figured adding a note to the release instructions might help me next time.